### PR TITLE
Add docker compose

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,34 @@
+# MD-Agent Architecture
+
+## System Overview
+MD-Agent is a multi-agent based intelligent document processing system built on the A2A protocol.
+
+## Components
+1. **Frontend**
+   - Streamlit UI (Phase 1)
+   - React UI (planned for Phase 2)
+   - Tailwind CSS styling
+   - Plotly visualizations
+
+2. **Backend**
+   - FastAPI REST API
+   - LangChain agent system
+   - LangGraph workflows
+   - LangSmith monitoring
+   - Async task processing
+   - WebSocket communication
+
+3. **Databases**
+   - Weaviate vector DB
+   - Chroma vector storage
+   - MySQL relational DB
+   - Redis cache
+
+4. **Infrastructure**
+   - Docker containers
+   - Docker Compose orchestration
+   - n8n workflow automation
+   - CI/CD pipeline
+   - Monitoring
+
+See the accompanying documentation for further details.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# multi-agent
+# Multi-Agent
+
+This repository provides a basic skeleton for the MD-Agent project. It includes
+placeholder code for a FastAPI backend and a Streamlit-based UI.
+See `ARCHITECTURE.md` for an overview of the planned system.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+def read_root():
+    return {"message": "Hello from MD-Agent backend"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.9'
+services:
+  backend:
+    image: python:3.11-slim
+    working_dir: /app
+    volumes:
+      - ./backend:/app
+    command: sh -c "pip install -r requirements.txt && uvicorn main:app --host 0.0.0.0 --port 8000"
+    ports:
+      - "8000:8000"
+  frontend:
+    image: python:3.11-slim
+    working_dir: /app
+    volumes:
+      - ./frontend:/app
+    command: sh -c "pip install -r requirements.txt && streamlit run streamlit_app.py --server.port 8501 --server.address 0.0.0.0"
+    ports:
+      - "8501:8501"

--- a/frontend/requirements.txt
+++ b/frontend/requirements.txt
@@ -1,0 +1,1 @@
+streamlit

--- a/frontend/streamlit_app.py
+++ b/frontend/streamlit_app.py
@@ -1,0 +1,4 @@
+import streamlit as st
+
+st.title("MD-Agent UI")
+st.write("This is a placeholder Streamlit interface for MD-Agent.")


### PR DESCRIPTION
## Summary
- provide a basic docker-compose.yml to run the backend and frontend

## Testing
- `python -m py_compile backend/main.py frontend/streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_684001f024a483338c1efcdd91c02b0e